### PR TITLE
Fixed deepl translator breaking the app if no API key is provided

### DIFF
--- a/generators/premiums/deepl_translator/__init__.py
+++ b/generators/premiums/deepl_translator/__init__.py
@@ -18,6 +18,7 @@ class DeeplTranslatorModel(BaseModel):
 
 def deepl_translator(req: DeeplTranslatorModel ):
     '''Uses DeepL API to translate texts.'''
+
     deepl_url = "https://api.deepl.com/v2/translate"
     params={ 
         "auth_key": req.apiKey, 
@@ -29,5 +30,9 @@ def deepl_translator(req: DeeplTranslatorModel ):
     deepl_url, 
     params=params
     ) 
+    try:
+        deepl_result_json = deepl_result.json()
+    except:
+        return "That didn't work. Maybe the API key is wrong?"
 
-    return deepl_result.json()
+    return deepl_result_json

--- a/generators/premiums/microsoft_translator/__init__.py
+++ b/generators/premiums/microsoft_translator/__init__.py
@@ -49,4 +49,7 @@ def microsoft_translator(req: MicrosoftTranslatorModel):
         json=body
     )
 
-    return request.json()
+    try:
+        return request.json()
+    except:
+        return "That didn't work. Maybe the API key is wrong?"


### PR DESCRIPTION
If no API key is provided, uvicorn threw an error because the deepl json was empty. Using a simple try except statement fixed that.