### PR TITLE
bs4 was somehow again missing from the requirements. Re adding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+beautifulsoup4==4.11.1
+better_profanity==0.7.0
 fastapi==0.85.1
 fire==0.4.0
 gunicorn==20.1.0
@@ -16,4 +18,3 @@ spacy==3.4.2
 quantulum3==0.7.11
 language_tool_python==2.7.1
 LeXmo==0.1.4
-better_profanity==0.7.0


### PR DESCRIPTION
Bs4 was missing from the requirements again. 