### PR TITLE
Fixed two errors in the sentence complexity and the vader module

### DIFF
--- a/classifiers/python_functions/sentence_complexity/code_snippet.md
+++ b/classifiers/python_functions/sentence_complexity/code_snippet.md
@@ -17,9 +17,9 @@ def set_all(d, keys, value):
     
 def get_mapping_complexity(score):
     if score < 0:
-        return outcomes[YOUR_MIN_SCORE]
+        return outcomes[0]
     if score > 100:
-        return outcomes[YOUR_MAX_SCORE]
+        return outcomes[100]
     return outcomes[int(score)]
 
 if YOUR_TARGET_LANGUAGE is not None:

--- a/classifiers/python_functions/vader_sentiment/code_snippet.md
+++ b/classifiers/python_functions/vader_sentiment/code_snippet.md
@@ -4,9 +4,9 @@ from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 YOUR_ATTRIBUTE: str = "text" # only text attributes
 YOUR_MODE: str = "classification" # choose "scores" to only get the sentiment scores as floats
 
-def vader_sentiment(req):
+def vader_sentiment(record):
     analyzer = SentimentIntensityAnalyzer()
-    text = req.text
+    text = record[YOUR_ATTRIBUTE].text
 
     vs = analyzer.polarity_scores(text)
     if YOUR_MODE == "classification":


### PR DESCRIPTION
PR checklist:
- [x] Tested by creator locally
- [x] Tested by creator on remote App
- [ ] Tested by reviewer locally
- [ ] Tested by reviewer on remote App
- [ ] Conforms with the agreed upon code pattern




