### PR TITLE
Percentage extractor

### DIFF
--- a/extractors/__init__.py
+++ b/extractors/__init__.py
@@ -34,6 +34,7 @@ from .python_functions import (
     noun_match_extraction,
     stock_ticker_extraction,
     verb_phrase_extraction,
+    percentage_extraction
 )
 
 from .premiums import (
@@ -78,6 +79,7 @@ for module in [
     noun_match_extraction,
     stock_ticker_extraction,
     verb_phrase_extraction,
+    percentage_extraction
 ]:
     module_name = module.__name__.split(".")[-1]
     model_name = (

--- a/extractors/python_functions/percentage_extraction/README.md
+++ b/extractors/python_functions/percentage_extraction/README.md
@@ -1,0 +1,1 @@
+This is a _crazy_ template for a _crazy_ module. The text from the README.md file is used as the module description in the details, whereas the docstring in the __init__.py file is used as the module description in the module overview.

--- a/extractors/python_functions/percentage_extraction/README.md
+++ b/extractors/python_functions/percentage_extraction/README.md
@@ -1,1 +1,1 @@
-This is a _crazy_ template for a _crazy_ module. The text from the README.md file is used as the module description in the details, whereas the docstring in the __init__.py file is used as the module description in the module overview.
+This module extracts percentages from a given text using a regex pattern. The percent sign will be extracted, too.

--- a/extractors/python_functions/percentage_extraction/__init__.py
+++ b/extractors/python_functions/percentage_extraction/__init__.py
@@ -1,19 +1,13 @@
-from pydantic import BaseModel
-from extractors.util.spacy import SpacySingleton
 from extractors.python_functions.regex_extraction import RegexExtractionModel, regex_extraction
 
 INPUT_EXAMPLE = {
-    # "text": "tricky percentage - .5  % with sloppy whitespaces is found between position 3 and 6",
-    "text": "percentages 110% are found -.5% at 50,25% positions 1, 5 and 8",
+    "text": "percentages 110% are found -.5% at 42,13% positions 1, 5 and 8",
     "spacyTokenizer": "en_core_web_sm",
 }
 
 
-# make sure the model name fits to the function name, as it is actually parsed
-# i.e. my_tagger -> MyTaggerModel (capitalized and "Model" appended)
 class PercentageExtractionModel(RegexExtractionModel):
-    # regex: str = r'\s*(-?\d+(?:[.,]\d*)?|-?[.,]\d+)\s*%'
-    regex: str = r'(-?\d+(?:[.,]\d*)?|-?[.,]\d+)%'
+    regex: str = r"(-?\d+(?:[.,]\d*)?|-?[.,]\d+)%"
     yourLabel: str = "percentage"
 
     class Config:
@@ -22,19 +16,5 @@ class PercentageExtractionModel(RegexExtractionModel):
 
 def percentage_extraction(request: PercentageExtractionModel):
     """Extracts percentages from a given text."""
-    ret = regex_extraction(request)
-    return ret
 
-    # text = request.text
-    # nlp = SpacySingleton.get_nlp(request.spacyTokenizer)
-    # doc = nlp(text)
-
-    # # my function logic here
-    # pattern = r'\s*(-?\d+(?:[.,]\d*)?|-?[.,]\d+)\s*%'
-    # percentages = re.findall(pattern, text)
-    # percentages =  [float(perc.replace(",", ".")) for perc in percentages]
-
-    # # append to the results triplets in the form of [label, start, end]
-
-    # # rename extractedEntities to whatever you want to call the output
-    # return {"extractedEntities": results}
+    return regex_extraction(request)

--- a/extractors/python_functions/percentage_extraction/__init__.py
+++ b/extractors/python_functions/percentage_extraction/__init__.py
@@ -1,4 +1,6 @@
-from extractors.python_functions.regex_extraction import RegexExtractionModel, regex_extraction
+from pydantic import BaseModel
+from extractors.util.spacy import SpacySingleton
+import re
 
 INPUT_EXAMPLE = {
     "text": "percentages 110% are found -.5% at 42,13% positions 1, 5 and 8",
@@ -6,8 +8,10 @@ INPUT_EXAMPLE = {
 }
 
 
-class PercentageExtractionModel(RegexExtractionModel):
+class PercentageExtractionModel(BaseModel):
+    text: str
     regex: str = r"(-?\d+(?:[.,]\d*)?|-?[.,]\d+)%"
+    spacyTokenizer: str = "en_core_web_sm"
     yourLabel: str = "percentage"
 
     class Config:
@@ -16,5 +20,29 @@ class PercentageExtractionModel(RegexExtractionModel):
 
 def percentage_extraction(request: PercentageExtractionModel):
     """Extracts percentages from a given text."""
+    nlp = SpacySingleton.get_nlp(request.spacyTokenizer)
+    doc = nlp(request.text)
 
-    return regex_extraction(request)
+    matches = []
+
+    def regex_search(pattern, string):
+        """
+        some helper function to easily iterate over regex matches
+        """
+        prev_end = 0
+        while True:
+            match = re.search(pattern, string)
+            if not match:
+                break
+
+            start, end = match.span()
+            yield start + prev_end, end + prev_end
+
+            prev_end += end
+            string = string[end:]
+
+    for start, end in regex_search(request.regex, request.text):
+        span = doc.char_span(start, end, alignment_mode="expand")
+        matches.append([request.yourLabel, span.start, span.end])
+
+    return {f"{request.yourLabel}s": matches}

--- a/extractors/python_functions/percentage_extraction/__init__.py
+++ b/extractors/python_functions/percentage_extraction/__init__.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+from extractors.util.spacy import SpacySingleton
+from extractors.python_functions.regex_extraction import RegexExtractionModel, regex_extraction
+
+INPUT_EXAMPLE = {
+    # "text": "tricky percentage - .5  % with sloppy whitespaces is found between position 3 and 6",
+    "text": "percentages 110% are found -.5% at 50,25% positions 1, 5 and 8",
+    "spacyTokenizer": "en_core_web_sm",
+}
+
+
+# make sure the model name fits to the function name, as it is actually parsed
+# i.e. my_tagger -> MyTaggerModel (capitalized and "Model" appended)
+class PercentageExtractionModel(RegexExtractionModel):
+    # regex: str = r'\s*(-?\d+(?:[.,]\d*)?|-?[.,]\d+)\s*%'
+    regex: str = r'(-?\d+(?:[.,]\d*)?|-?[.,]\d+)%'
+    yourLabel: str = "percentage"
+
+    class Config:
+        schema_extra = {"example": INPUT_EXAMPLE}
+
+
+def percentage_extraction(request: PercentageExtractionModel):
+    """Extracts percentages from a given text."""
+    ret = regex_extraction(request)
+    return ret
+
+    # text = request.text
+    # nlp = SpacySingleton.get_nlp(request.spacyTokenizer)
+    # doc = nlp(text)
+
+    # # my function logic here
+    # pattern = r'\s*(-?\d+(?:[.,]\d*)?|-?[.,]\d+)\s*%'
+    # percentages = re.findall(pattern, text)
+    # percentages =  [float(perc.replace(",", ".")) for perc in percentages]
+
+    # # append to the results triplets in the form of [label, start, end]
+
+    # # rename extractedEntities to whatever you want to call the output
+    # return {"extractedEntities": results}

--- a/extractors/python_functions/percentage_extraction/code_snippet.md
+++ b/extractors/python_functions/percentage_extraction/code_snippet.md
@@ -1,0 +1,9 @@
+```python
+def my_tagger(record): 
+    yield "label", start, end
+```
+
+_Notes, remove them when you're finished_:
+- The record is a dictionary, you can retrieve text e.g. as `record["my_attribute"].text`, as the record is already tokenized by spaCy.
+- The function `yield`s tuples of the label and the start and end position of the label in the text.
+- What is written here will be copied to refinery; it must fit the interface of what refinery expects.

--- a/extractors/python_functions/percentage_extraction/code_snippet.md
+++ b/extractors/python_functions/percentage_extraction/code_snippet.md
@@ -1,7 +1,7 @@
 ```python
 import re
 
-YOUR_REGEX: str = r"(-?\d+(?:[.,]\d*)?|-?[.,]\d+)%" # this will caputre all percentages
+YOUR_REGEX: str = r"(-?\d+(?:[.,]\d*)?|-?[.,]\d+)%" # this will capture all percentages
 YOUR_ATTRIBUTE: str = "text" # only text attributes
 YOUR_LABEL: str = "percentage" # Choose any available label here
 

--- a/extractors/python_functions/percentage_extraction/code_snippet.md
+++ b/extractors/python_functions/percentage_extraction/code_snippet.md
@@ -1,9 +1,26 @@
 ```python
-def my_tagger(record): 
-    yield "label", start, end
-```
+import re
 
-_Notes, remove them when you're finished_:
-- The record is a dictionary, you can retrieve text e.g. as `record["my_attribute"].text`, as the record is already tokenized by spaCy.
-- The function `yield`s tuples of the label and the start and end position of the label in the text.
-- What is written here will be copied to refinery; it must fit the interface of what refinery expects.
+YOUR_REGEX: str = r"(-?\d+(?:[.,]\d*)?|-?[.,]\d+)%" # this will caputre all percentages
+YOUR_ATTRIBUTE: str = "text" # only text attributes
+YOUR_LABEL: str = "percentage" # Choose any available label here
+
+def percentage_extraction(record):
+
+    def regex_search(pattern, string):
+        prev_end = 0
+        while True:
+            match = re.search(pattern, string)
+            if not match:
+                break
+
+            start_, end_ = match.span()
+            yield start_ + prev_end, end_ + prev_end
+
+            prev_end += end_
+            string = string[end_:]
+            
+    for start, end in regex_search(YOUR_REGEX, record[YOUR_ATTRIBUTE].text):
+        span = record[YOUR_ATTRIBUTE].char_span(start, end, alignment_mode="expand")
+        yield YOUR_LABEL, span.start, span.end
+```

--- a/extractors/python_functions/percentage_extraction/config.py
+++ b/extractors/python_functions/percentage_extraction/config.py
@@ -8,8 +8,8 @@ def get_config():
         function=percentage_extraction,
         input_example=INPUT_EXAMPLE,
         data_type="text",
-        issue_id=-1,  # you need to look this up in the issues https://github.com/code-kern-ai/bricks/issues
-        tabler_icon="Template", # Add any fitting icon from tabler-icons.io
-        min_refinery_version="x.x.x",  # you need to look this up in the issues
-        state=State.PUBLIC, # in the actual module, set this to PUBLIC before pushing to main!
+        issue_id=149,
+        tabler_icon="IconPercentage",
+        min_refinery_version="1.9.0",
+        state=State.PUBLIC,
     )

--- a/extractors/python_functions/percentage_extraction/config.py
+++ b/extractors/python_functions/percentage_extraction/config.py
@@ -1,0 +1,15 @@
+from util.configs import build_extractor_function_config
+from util.enums import State
+from . import percentage_extraction, INPUT_EXAMPLE
+
+
+def get_config():
+    return build_extractor_function_config(
+        function=percentage_extraction,
+        input_example=INPUT_EXAMPLE,
+        data_type="text",
+        issue_id=-1,  # you need to look this up in the issues https://github.com/code-kern-ai/bricks/issues
+        tabler_icon="Template", # Add any fitting icon from tabler-icons.io
+        min_refinery_version="x.x.x",  # you need to look this up in the issues
+        state=State.PUBLIC, # in the actual module, set this to PUBLIC before pushing to main!
+    )


### PR DESCRIPTION
PR checklist:
- [x] Tested by creator locally
- [x] Tested by creator on remote App
- [x] Tested by reviewer locally
- [x] Tested by reviewer on remote App
- [x] Conforms with the agreed upon code pattern

Tested on `localhost:8000/docs`, not yet on refinery.
If you for some reason dislike inheriting from regex_extraction, I have a boilerplate version ready.
One could get more fancy with decimal points and whitespaces, e.g. `"1.000,25    %"`, but I kept it simple for now.

Hope this passes! :)




