### PR TITLE
Toxicity classifier with toxic-bert

### DIFF
--- a/classifiers/__init__.py
+++ b/classifiers/__init__.py
@@ -12,7 +12,8 @@ from .python_functions import (
     vader_sentiment,
 )
 from .premiums import (
-    gpt3_classifier
+    gpt3_classifier,
+    toxicity_classifier
 )
 
 router = APIRouter()
@@ -29,6 +30,7 @@ for module in [
     profanity_detection,
     gpt3_classifier,
     vader_sentiment,
+    toxicity_classifier
 ]:
     module_name = module.__name__.split(".")[-1]
     model_name = (

--- a/classifiers/premiums/toxicity_classifier/README.md
+++ b/classifiers/premiums/toxicity_classifier/README.md
@@ -1,0 +1,3 @@
+Uses the `unitary/toxic-bert` model from Hugging Face Hub to classify toxicity in text. Outputs various labels and their respective scores. An API key can be obtained directly from Hugging Face Inference API. Contact us at info@kern.ai if you require an API key or need any support from us. Community contibtion by @rasdani.
+
+Check out Hugging Face Hub for example: https://huggingface.co/unitary/toxic-bert

--- a/classifiers/premiums/toxicity_classifier/__init__.py
+++ b/classifiers/premiums/toxicity_classifier/__init__.py
@@ -1,0 +1,29 @@
+import requests
+from pydantic import BaseModel
+
+INPUT_EXAMPLE = {
+    "apiToken": "<API_KEY_GOES_HERE>",
+    "text": "Shut your mouth, you idiot!"
+}
+
+API_URL = "https://api-inference.huggingface.co/models/unitary/toxic-bert"
+
+class ToxicityClassifierModel(BaseModel):
+    apiToken: str
+    text: str
+
+    class Config:
+        schema_example = {"example": INPUT_EXAMPLE}
+
+
+def toxicity_classifier(req: ToxicityClassifierModel):
+    def query(api_token, inputs):
+        headers = {"Authorization": f"Bearer {api_token}"}
+        response = requests.post(API_URL, headers=headers, json={"inputs": inputs})
+        return response.json()
+
+    try:
+        output = query(req.apiToken, req.text)
+        return output
+    except:
+        return "That didn't work. Did you provide a valid Hugging Face API key?"

--- a/classifiers/premiums/toxicity_classifier/code_snippet.md
+++ b/classifiers/premiums/toxicity_classifier/code_snippet.md
@@ -1,0 +1,18 @@
+```python
+import requests
+
+YOUR_API_KEY: str = "<API_KEY_GOES_HERE>"
+API_URL = "https://api-inference.huggingface.co/models/unitary/toxic-bert"
+YOUR_ATTRIBUTE: str = "text" # only text attributes
+
+def toxicity_classifier(record):
+    """
+    Uses toxic-bert via Hugging Face Inference API to classify toxicity in text. Visit https://huggingface.co/unitary/toxic-bert for full documentation 
+    """
+    api_token = YOUR_API_KEY
+    inputs = record[YOUR_ATTRIBUTE].text
+
+    headers = {"Authorization": f"Bearer {api_token}"}
+    response = requests.post(API_URL, headers=headers, json={"inputs": inputs})
+    return response.json()
+```

--- a/classifiers/premiums/toxicity_classifier/config.py
+++ b/classifiers/premiums/toxicity_classifier/config.py
@@ -1,0 +1,15 @@
+from util.configs import build_classifier_premium_config
+from util.enums import State
+from . import toxicity_classifier, INPUT_EXAMPLE
+
+
+def get_config():
+    return build_classifier_premium_config(
+        function=toxicity_classifier,
+        input_example=INPUT_EXAMPLE,
+        data_type="text",
+        issue_id=80,
+        tabler_icon="MoodAngry",
+        min_refinery_version="1.8.0",
+        state=State.PUBLIC
+    )


### PR DESCRIPTION
PR checklist:
- [x] Tested by creator locally
- [ ] Tested by creator on remote App
- [ ] Tested by reviewer locally
- [ ] Tested by reviewer on remote App
- [ ] Conforms with the agreed upon code pattern

Uses `unitary/toxic-bert` from [Hugging Face Hub](https://huggingface.co/unitary/toxic-bert).

Returns labels in this format:
```
[
  [
    {
      "label": "toxic",
      "score": 0.8740649223327637
    },
    {
      "label": "threat",
      "score": 0.858504056930542
    },
    {
      "label": "severe_toxic",
      "score": 0.0962657630443573
    },
    {
      "label": "insult",
      "score": 0.09431260824203491
    },
    {
      "label": "obscene",
      "score": 0.07479805499315262
    },
    {
      "label": "identity_hate",
      "score": 0.04400772228837013
    }
  ]
]
```

Hugging Face API responds with informative error messages, if something goes wrong. I could return them, too.

Tested locally on bricks with Hugging Face's Free Inference API for prototyping. 
Tried to test on refinery but ran into [issues](https://github.com/code-kern-ai/refinery/issues/245).