### PR TITLE
Add support for Azure, Palm, Anthropic, Cohere, Hugging Face Llama2 70b Models - using litellm 

### DIFF
--- a/classifiers/llm/gpt_classifier/__init__.py
+++ b/classifiers/llm/gpt_classifier/__init__.py
@@ -1,4 +1,5 @@
 import openai
+from litellm import completion
 from pydantic import BaseModel
 from typing import List
 
@@ -27,7 +28,7 @@ def gpt_classifier(req: GptClassifierModel):
 
     openai.api_key = req.apiKey
     try:
-        response = openai.ChatCompletion.create(
+        response = completion(
             model="gpt-3.5-turbo",
             messages=[
                 {

--- a/extractors/llm/gpt_information_extraction/__init__.py
+++ b/extractors/llm/gpt_information_extraction/__init__.py
@@ -1,6 +1,7 @@
 import re
 import ast
 import openai
+from litellm import completion
 from extractors.util.spacy import SpacySingleton
 from pydantic import BaseModel
 
@@ -28,7 +29,7 @@ def gpt_information_extraction(req: GptInformationExtractionModel):
     """Uses OpenAI's GPT model to extract keyword from a text."""
     openai.api_key = req.apiKey
     try: 
-        response = openai.ChatCompletion.create(
+        response = completion(
             model = "gpt-3.5-turbo",
             messages = [
                 {

--- a/generators/llm/gpt_grammar_correction/__init__.py
+++ b/generators/llm/gpt_grammar_correction/__init__.py
@@ -1,4 +1,5 @@
 import openai
+from litellm import completion
 from pydantic import BaseModel
 
 INPUT_EXAMPLE = {
@@ -21,7 +22,7 @@ def gpt_grammar_correction(req: GptGrammarCorrectionModel):
     """GPT-3.5 model which can be used to correct grammar."""
     openai.api_key = req.apiKey
     try:
-        response = openai.ChatCompletion.create(
+        response = completion(
             model="gpt-3.5-turbo",
             messages=[
                 {

--- a/generators/llm/gpt_tldr_summarization/__init__.py
+++ b/generators/llm/gpt_tldr_summarization/__init__.py
@@ -1,5 +1,6 @@
 import openai
 from pydantic import BaseModel
+from litellm import completion
 
 INPUT_EXAMPLE = {
     "apiKey": "<API_KEY_GOES_HERE>",
@@ -21,7 +22,7 @@ def gpt_tldr_summarization(req: GptTldrSummarizationModel):
     """GPT-3.5 model which can be used to summarize text inputs."""
     openai.api_key = req.apiKey
     try:
-        response = openai.ChatCompletion.create(
+        response = completion(
             model="gpt-3.5-turbo",
             messages=[
                 {


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

All LLM API Models are guaranteed to have the same Input/Output interface 

Here's a sample of how it's used:

```python
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"
os.environ["HF_API_TOKEN"] = "hf-key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# hugging face llama2 call
completion(model="meta-llama/llama-2-7b-hf", messages=messages)

# hugging face llama2 Guanaco call
completion(model="TheBloke/llama-2-70b-Guanaco-QLoRA-fp16", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```

PR checklist:
- [ ] Tested by creator on localhost:8000/docs
- [ ] Tested by creator on refinery
- [ ] Tested by reviewer on localhost:8000/docs
- [ ] Tested by reviewer on refinery
- [ ] (If added) common code tested in notebook/ script
- [ ] Conforms with the agreed upon code pattern




