### PR TITLE
Newline splitter

### DIFF
--- a/generators/__init__.py
+++ b/generators/__init__.py
@@ -16,6 +16,10 @@ from .paths import (
     domain_parser,
 )
 
+from .reference_chunking import (
+    newline_splitter
+)
+
 from .search import (
     bing_news_search,
     bing_search,
@@ -96,6 +100,7 @@ for module in [
     bert_toxicity_detector,
     gpt_grammar_correction,
     gpt_tldr_summarization,
+    newline_splitter
 ]:
     module_name = module.__name__.split(".")[-1]
     model_name = (

--- a/generators/reference_chunking/newline_splitter/README.md
+++ b/generators/reference_chunking/newline_splitter/README.md
@@ -1,0 +1,1 @@
+This brick splits a text into smaller pieces by newline characters. It can be used for the 'embedding list' attribute in refinery to increase the accuracy for similarity search. 

--- a/generators/reference_chunking/newline_splitter/__init__.py
+++ b/generators/reference_chunking/newline_splitter/__init__.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+INPUT_EXAMPLE = {
+    "text": "https://huggingface.co/sentence-transformers",
+}
+
+class NewlineSplitterModel(BaseModel):
+    text: str
+
+    class Config:
+        schema_extra = {"example": INPUT_EXAMPLE}
+
+
+def newline_splitter(req: NewlineSplitterModel):
+    """Splits a text by newline characters"""
+    splits = req.text.split("\n")
+    return {"splitted_text" :[val for val in splits if len(val) > 0]}
+
+

--- a/generators/reference_chunking/newline_splitter/__init__.py
+++ b/generators/reference_chunking/newline_splitter/__init__.py
@@ -1,7 +1,10 @@
 from pydantic import BaseModel
 
 INPUT_EXAMPLE = {
-    "text": "https://huggingface.co/sentence-transformers",
+    "text": """This is the first line.
+    And this is the second line.
+    Here's a third one, too.
+    """,
 }
 
 class NewlineSplitterModel(BaseModel):
@@ -13,7 +16,7 @@ class NewlineSplitterModel(BaseModel):
 
 def newline_splitter(req: NewlineSplitterModel):
     """Splits a text by newline characters"""
-    splits = req.text.split("\n")
-    return {"splitted_text" :[val for val in splits if len(val) > 0]}
+    splits = req.text.strip().split("\n")
+    return {"splitted_text" : [val for val in splits if len(val) > 0]}
 
 

--- a/generators/reference_chunking/newline_splitter/__init__.py
+++ b/generators/reference_chunking/newline_splitter/__init__.py
@@ -17,6 +17,6 @@ class NewlineSplitterModel(BaseModel):
 def newline_splitter(req: NewlineSplitterModel):
     """Splits a text by newline characters"""
     splits = req.text.split("\n")
-    return {"splitted_text" : [val for val in splits if len(val.strip()) > 0]}
+    return {"splitted_text" : [val.strip() for val in splits if len(val) > 0]}
 
 

--- a/generators/reference_chunking/newline_splitter/__init__.py
+++ b/generators/reference_chunking/newline_splitter/__init__.py
@@ -16,7 +16,7 @@ class NewlineSplitterModel(BaseModel):
 
 def newline_splitter(req: NewlineSplitterModel):
     """Splits a text by newline characters"""
-    splits = req.text.split("\n")
-    return {"splitted_text" : [val.strip() for val in splits if len(val) > 0]}
+    splits = [t.strip() for t in req.text.split("\n")]
+    return {"splitted_text" : [val for val in splits if len(val) > 0]}
 
 

--- a/generators/reference_chunking/newline_splitter/code_snippet_common.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_common.md
@@ -2,6 +2,10 @@
 from typing import List 
 
 def newline_splitter(text: str) -> List[str]:
+    """
+    @param text: The input string that needs to be split.
+    @return:  A list of strings where each string is a non-empty line from the input.
+    """
     splits = text.strip().split("\n")
     return [val for val in splits if len(val) > 0]
 

--- a/generators/reference_chunking/newline_splitter/code_snippet_common.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_common.md
@@ -19,7 +19,7 @@ def example_integration():
     This too, but in another line
     """, "This is a sentence\nwith a newline literal!"]
     for text in texts:
-        print(f"The text {text} was split into {newline_splitter(text)}")
+        print(f"The text {repr(text)} was split into {newline_splitter(text)}")
 
 example_integration()
 ```

--- a/generators/reference_chunking/newline_splitter/code_snippet_common.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_common.md
@@ -6,8 +6,8 @@ def newline_splitter(text: str) -> List[str]:
     @param text: The input string that needs to be split.
     @return:  A list of strings where each string is a non-empty line from the input.
     """
-    splits = text.strip().split("\n")
-    return [val for val in splits if len(val) > 0]
+    splits = text.split("\n")
+    return [val.strip() for val in splits if len(val) > 0]
 
 # ↑ necessary bricks function 
 # -----------------------------------------------------------------------------------------

--- a/generators/reference_chunking/newline_splitter/code_snippet_common.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_common.md
@@ -1,0 +1,21 @@
+```python
+from typing import List 
+
+def newline_splitter(text: str) -> List[str]:
+    splits = text.split("\n")
+    return [val for val in splits if len(val) > 0]
+
+# ↑ necessary bricks function 
+# -----------------------------------------------------------------------------------------
+# ↓ example implementation
+
+def example_integration():
+    texts = ["""
+    This is a sentences.
+    This too, but in another line
+    """]
+    for text in texts:
+        print(f"The text {text} was split into {newline_splitter(text)}")
+
+example_integration()
+```

--- a/generators/reference_chunking/newline_splitter/code_snippet_common.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_common.md
@@ -6,8 +6,8 @@ def newline_splitter(text: str) -> List[str]:
     @param text: The input string that needs to be split.
     @return:  A list of strings where each string is a non-empty line from the input.
     """
-    splits = text.split("\n")
-    return [val.strip() for val in splits if len(val) > 0]
+    splits = [t.strip() for t in text.split("\n")]
+    return [val for val in splits if len(val) > 0]
 
 # ↑ necessary bricks function 
 # -----------------------------------------------------------------------------------------

--- a/generators/reference_chunking/newline_splitter/code_snippet_common.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_common.md
@@ -2,7 +2,7 @@
 from typing import List 
 
 def newline_splitter(text: str) -> List[str]:
-    splits = text.split("\n")
+    splits = text.strip().split("\n")
     return [val for val in splits if len(val) > 0]
 
 # ↑ necessary bricks function 

--- a/generators/reference_chunking/newline_splitter/code_snippet_refinery.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_refinery.md
@@ -1,7 +1,7 @@
 ```python
 ATTRIBUTE: str = "text" # only text attributes
 
-def newline_splitter(text: str) -> List[str]:
-    splits = text.strip().split("\n")
+def newline_splitter(record):
+    splits = record[ATTRIBUTE].text.strip().split("\n")
     return [val for val in splits if len(val) > 0]
 ```

--- a/generators/reference_chunking/newline_splitter/code_snippet_refinery.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_refinery.md
@@ -1,0 +1,7 @@
+```python
+ATTRIBUTE: str = "text" # only text attributes
+
+def newline_splitter(text: str) -> List[str]:
+    splits = text.strip().split("\n")
+    return [val for val in splits if len(val) > 0]
+```

--- a/generators/reference_chunking/newline_splitter/code_snippet_refinery.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_refinery.md
@@ -2,6 +2,6 @@
 ATTRIBUTE: str = "text" # only text attributes
 
 def newline_splitter(record):
-    splits = record[ATTRIBUTE].text.strip().split("\n")
-    return [val for val in splits if len(val) > 0]
+    splits = record[ATTRIBUTE].text.split("\n")
+    return [val.strip() for val in splits if len(val) > 0]
 ```

--- a/generators/reference_chunking/newline_splitter/code_snippet_refinery.md
+++ b/generators/reference_chunking/newline_splitter/code_snippet_refinery.md
@@ -2,6 +2,6 @@
 ATTRIBUTE: str = "text" # only text attributes
 
 def newline_splitter(record):
-    splits = record[ATTRIBUTE].text.split("\n")
-    return [val.strip() for val in splits if len(val) > 0]
+    splits = [t.strip() for t in record[ATTRIBUTE].text.split("\n")]
+    return [val for val in splits if len(val) > 0]
 ```

--- a/generators/reference_chunking/newline_splitter/config.py
+++ b/generators/reference_chunking/newline_splitter/config.py
@@ -1,0 +1,35 @@
+from util.configs import build_generator_premium_config
+from util.enums import State, RefineryDataType, BricksVariableType, SelectionType
+from . import newline_splitter, INPUT_EXAMPLE
+
+
+def get_config():
+    return build_generator_premium_config(
+        function=newline_splitter,
+        input_example=INPUT_EXAMPLE,
+        issue_id=367,
+        tabler_icon="Slice",
+        min_refinery_version="1.7.0",
+        state=State.PUBLIC.value,
+        type="python_function",
+        available_for=["refinery", "common"],
+        part_of_group=[
+            "reference_chunking",
+        ],  # first entry should be parent directory
+        # bricks integrator information
+        integrator_inputs={
+            "name": "domain_parser",
+            "refineryDataType": RefineryDataType.TEXT.value,
+            "variables": {
+                "ATTRIBUTE": {
+                    "selectionType": SelectionType.CHOICE.value,
+                    "optional": "false",
+                    "addInfo": [
+                        BricksVariableType.ATTRIBUTE.value,
+                        BricksVariableType.GENERIC_STRING.value,
+                    ],
+                },
+
+            },
+        },
+    )

--- a/generators/reference_chunking/newline_splitter/config.py
+++ b/generators/reference_chunking/newline_splitter/config.py
@@ -18,8 +18,8 @@ def get_config():
         ],  # first entry should be parent directory
         # bricks integrator information
         integrator_inputs={
-            "name": "domain_parser",
-            "refineryDataType": RefineryDataType.TEXT.value,
+            "name": "newline_splitter",
+            "refineryDataType": RefineryDataType.EMBEDDING_LIST.value,
             "variables": {
                 "ATTRIBUTE": {
                     "selectionType": SelectionType.CHOICE.value,

--- a/util/enums.py
+++ b/util/enums.py
@@ -37,3 +37,4 @@ class RefineryDataType(Enum):
     INTEGER = "integer"
     FLOAT = "float"
     BOOLEAN = "boolean"
+    EMBEDDING_LIST = "embedding_list"


### PR DESCRIPTION
refinery
- [x] Tested by creator on refinery
- [x] Tested by reviewer on refinery
- [x] Ensured that output of brick conforms with refinery structure (to be checked by reviewer)

API
- [x] Tested by creator on localhost:8000/docs
- [x] Tested by reviewer on localhost:8000/docs

common code
- [x] Common code tested in notebook/ script by creator
- [x] Common code tested in notebook/ script by reviewer
- [x] Common code contains docstrings and type hints

additional points:
- [x] Docstring and README is existing
- [x] Import statements (in `__init__.py`)
- [x] (If necessary) Added dependency to requirements.txt
- [x] (If necessary) Added dependency to issue for refinery env [here](https://github.com/code-kern-ai/refinery/issues/166)
- [x] Published brick to Strapi CMS (locally)


Testing procedure: 
When testing in refinery, please ensure that the output of the brick conforms with the structure of refinery. 
For `extraction` bricks, this would be a tuple like `("label", span_start, span_end)`.
For `classification` bricks, this would be a string representing a label.
For `generator` bricks, this would either be a float, interger, string, boolean or a list, depending on the situation.

When testing the bricks, try to avoid using only one source of data. Meaning that you should not only use the `clickbait` sample
project, but also different texts with longer or more complex strings. 

A small refinery example project with a variation of texts called `bricks-test-data-project.zip` can be found in the bricks repository.

Implements #367 
