### PR TITLE
Adding n-gram generator module to generators, implements #279.

### DIFF
--- a/generators/__init__.py
+++ b/generators/__init__.py
@@ -65,6 +65,10 @@ from .llm import (
 
 from .sentiment import vader_sentiment_scores
 
+from .ngram import (
+    nltk_ngram_generator
+)
+
 router = APIRouter()
 
 for module in [
@@ -102,6 +106,7 @@ for module in [
     newline_splitter,
     tiktoken_token_counter,
     noun_splitter,
+    nltk_ngram_generator,  
 ]:
     module_name = module.__name__.split(".")[-1]
     model_name = (

--- a/generators/ngram/nltk_ngram_generator/README.md
+++ b/generators/ngram/nltk_ngram_generator/README.md
@@ -1,0 +1,6 @@
+
+This nltk-based n-gram generator allows to generate word n-grams from a given input sentence. Utilizes the spaCy tokenizer for tokenization. An n-gram is a contiguous sequence of 'n' words from a text. For example, in the sentence "The quick brown fox", the 2-grams (bigrams) are "The quick" and "quick brown", and "brown fox". 
+Users can specify the size of the n-grams, ranging from bigrams (2-grams) to n-grams of any size, as well as spaCy language model (default is en_core_web_sm). 
+More about spaCy: https://spacy.io/usage/models
+More about nltk: https://www.nltk.org/index.html
+

--- a/generators/ngram/nltk_ngram_generator/__init__.py
+++ b/generators/ngram/nltk_ngram_generator/__init__.py
@@ -1,0 +1,28 @@
+from nltk.util import ngrams
+from pydantic import BaseModel
+from generators.util.spacy import SpacySingleton
+
+INPUT_EXAMPLE = {"sentence": "Despite the unpredictable weather, the enthusiastic crowd gathered at the park for the annual summer festival, eagerly anticipating an evening filled with music, food, and vibrant celebrations.",
+                "spacyTokenizer": "en_core_web_sm",
+                "ngram_size": 2}
+
+
+class NltkNgramGeneratorModel(BaseModel):
+    sentence: str
+    spacyTokenizer: str = "en_core_web_sm"
+    ngram_size: int = 2
+
+    class Config:
+        schema_extra = {"example": INPUT_EXAMPLE}
+
+
+def nltk_ngram_generator(req: NltkNgramGeneratorModel):
+    """Generate word n-grams from the input sentence. Punctuation and stop words are preserved."""
+    sentence = req.sentence
+    ngram_size = req.ngram_size
+    nlp = SpacySingleton.get_nlp(req.spacyTokenizer)
+    doc = nlp(sentence)
+    tokens = [token.text for token in doc]
+    n_grams = list(ngrams(tokens, ngram_size))
+
+    return {"n_grams": n_grams}

--- a/generators/ngram/nltk_ngram_generator/code_snippet_backup.md
+++ b/generators/ngram/nltk_ngram_generator/code_snippet_backup.md
@@ -1,0 +1,23 @@
+```python
+import spacy
+from nltk.util import ngrams
+
+# replace this list with a list containing your data
+text = ["Despite the unpredictable weather, the enthusiastic crowd gathered at the park for the annual summer festival, eagerly anticipating an evening filled with music, food, and vibrant celebrations."]
+
+# add the texts to a dict called records. Add further information as key-value pairs if needed
+record = {
+    "sentence": text,
+    "ngram_size": 2
+}
+
+def nltk_ngram_generator(record):
+    nlp = spacy.load("en_core_web_sm")
+    doc = nlp(record.sentence)
+    tokens  =[token.text for token in doc]
+    n_grams = list(ngrams(tokens, record["ngram_size"]))
+
+    return {"n_grams": n_grams}
+```
+
+

--- a/generators/ngram/nltk_ngram_generator/code_snippet_common.md
+++ b/generators/ngram/nltk_ngram_generator/code_snippet_common.md
@@ -1,0 +1,30 @@
+```python
+import spacy
+from nltk.util import ngrams
+from typing import List, Tuple
+
+def nltk_ngram_generator(sentence: str, ngram_size: int = 2) -> List[Tuple[str, ...]]:
+    """Generate word n-grams from the input sentence. Punctuation and stop words are preserved.
+    @param sentence: The input sentence from which n-grams will be generated. 
+    @param ngram_size: The size of each n-gram. Default: 2. This parameter specifies the number of consecutive words that will be included in each n-gram. For example, an ngram_size of 2 will produce bigrams. 
+    @return: A list where each element is a tuple of strings (words), with each tuple representing an n-gram. The size of each tuple (i.e., the number of words it contains) corresponds to the 'ngram_size' specified.
+    """
+    nlp = spacy.load("en_core_web_sm")
+    doc = nlp(sentence)
+    tokens = [token.text for token in doc]
+    n_grams = list(ngrams(tokens, ngram_size))
+
+    return n_grams
+    
+# ↑ necessary bricks function 
+# -----------------------------------------------------------------------------------------
+# ↓ example implementation 
+
+def example_integration():
+    sentences = ["Despite the unpredictable weather, the enthusiastic crowd gathered at the park for the annual summer festival, eagerly anticipating an evening filled with music, food, and vibrant celebrations.", "The rapidly advancing technology sector offers exciting opportunities and significant challenges, sparking debates among experts and novices alike."]
+
+    for i, sentence in enumerate(sentences):
+        print(f"N_grams for sentence {i+1} are: {nltk_ngram_generator(sentence)}")
+
+example_integration()
+```

--- a/generators/ngram/nltk_ngram_generator/code_snippet_refinery.md
+++ b/generators/ngram/nltk_ngram_generator/code_snippet_refinery.md
@@ -1,0 +1,13 @@
+```python
+from nltk.util import ngrams
+ATTRIBUTE: str = "text" # only text fields
+NGRAM_SIZE: int = 2
+
+def nltk_ngram_generator(record):
+
+    tokens = [token.text for token in record[ATTRIBUTE]]
+    n_grams = list(ngrams(tokens, NGRAM_SIZE))
+    n_grams_str = str(n_grams).strip('[]')
+
+    return n_grams_str
+```

--- a/generators/ngram/nltk_ngram_generator/config.py
+++ b/generators/ngram/nltk_ngram_generator/config.py
@@ -1,11 +1,11 @@
 from util.configs import build_generator_function_config
 from util.enums import State, RefineryDataType, BricksVariableType, SelectionType
-from . import nltk_ngram, INPUT_EXAMPLE
+from . import nltk_ngram_generator, INPUT_EXAMPLE
 
 
 def get_config():
     return build_generator_function_config(
-        function=nltk_ngram,
+        function=nltk_ngram_generator,
         input_example=INPUT_EXAMPLE,
         issue_id=279,
         tabler_icon="Transform",

--- a/generators/ngram/nltk_ngram_generator/config.py
+++ b/generators/ngram/nltk_ngram_generator/config.py
@@ -17,17 +17,27 @@ def get_config():
             "ngram",
         ],  # first entry should be parent directory
         # bricks integrator information
-        integrator_inputs={
-            "name": "nltk_ngram_generator",
-            "refineryDataType": RefineryDataType.TEXT.value,
-            "variables": {
-                "ATTRIBUTE": {
-                    "selectionType": SelectionType.CHOICE.value,
-                    "addInfo": [
-                        BricksVariableType.ATTRIBUTE.value,
-                        BricksVariableType.GENERIC_STRING.value,
-                    ],
-                }
-            },
+integrator_inputs={
+    "name": "nltk_ngram_generator",
+    "refineryDataType": RefineryDataType.TEXT.value,
+    "variables": {
+        "ATTRIBUTE": {
+            "selectionType": SelectionType.CHOICE.value,
+            "description": "only text fields",
+            "optional": "false",
+            "addInfo": [
+                BricksVariableType.ATTRIBUTE.value,
+                BricksVariableType.GENERIC_STRING.value
+            ]
         },
+        "NGRAM_SIZE": {
+            "selectionType": SelectionType.INTEGER.value,
+            "defaultValue": 2,
+            "optional": "false",
+            "addInfo": [
+                BricksVariableType.GENERIC_INT.value
+            ]
+        }
+    }
+}
     )

--- a/generators/ngram/nltk_ngram_generator/config.py
+++ b/generators/ngram/nltk_ngram_generator/config.py
@@ -1,0 +1,33 @@
+from util.configs import build_generator_function_config
+from util.enums import State, RefineryDataType, BricksVariableType, SelectionType
+from . import nltk_ngram, INPUT_EXAMPLE
+
+
+def get_config():
+    return build_generator_function_config(
+        function=nltk_ngram,
+        input_example=INPUT_EXAMPLE,
+        issue_id=279,
+        tabler_icon="Transform",
+        min_refinery_version="1.7.0",
+        state=State.PUBLIC.value,
+        type="python_function",
+        available_for=["refinery", "common"],
+        part_of_group=[
+            "ngram",
+        ],  # first entry should be parent directory
+        # bricks integrator information
+        integrator_inputs={
+            "name": "nltk_ngram_generator",
+            "refineryDataType": RefineryDataType.TEXT.value,
+            "variables": {
+                "ATTRIBUTE": {
+                    "selectionType": SelectionType.CHOICE.value,
+                    "addInfo": [
+                        BricksVariableType.ATTRIBUTE.value,
+                        BricksVariableType.GENERIC_STRING.value,
+                    ],
+                }
+            },
+        },
+    )


### PR DESCRIPTION
refinery
- [ ] Tested by creator on refinery
- [x] Tested by reviewer on refinery
- [x] Ensured that output of brick conforms with refinery structure (to be checked by reviewer)

API
- [x] Tested by creator on localhost:8000/docs
- [x] Tested by reviewer on localhost:8000/docs

common code
- [x] Common code tested in notebook/ script by creator
- [x] Common code tested in notebook/ script by reviewer
- [x] Common code contains docstrings and type hints

additional points:
- [x] Docstring and README is existing
- [x] Import statements (in `__init__.py`)
- [ ] (If necessary) Added dependency to requirements.txt
- [ ] (If necessary) Added dependency to issue for refinery env [here](https://github.com/code-kern-ai/refinery/issues/166)
- [ ] Published brick to Strapi CMS (locally)


Testing procedure: 
When testing in refinery, please ensure that the output of the brick conforms with the structure of refinery. 
For `extraction` bricks, this would be a tuple like `("label", span_start, span_end)`.
For `classification` bricks, this would be a string representing a label.
For `generator` bricks, this would either be a float, interger, string, boolean or a list, depending on the situation.

When testing the bricks, try to avoid using only one source of data. Meaning that you should not only use the `clickbait` sample
project, but also different texts with longer or more complex strings. 

A small refinery example project with a variation of texts called `bricks-test-data-project.zip` can be found in the bricks repository.


